### PR TITLE
Extract-archive-error

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,6 @@
   check_mode: false
 
 - name: Unpack uptime-kuma src archive
-  become: false
   ansible.builtin.unarchive:
     src: "/tmp/uptime_kuma_{{ uptime_kuma_version }}.tar.gz"
     dest: "{{ uptime_kuma_home }}"
@@ -35,7 +34,6 @@
   check_mode: false
 
 - name: Unpack uptime-kuma dist archive
-  become: false
   ansible.builtin.unarchive:
     src: "/tmp/uptime_kuma_{{ uptime_kuma_version }}_dist.tar.gz"
     dest: "{{ uptime_kuma_src }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -44,8 +44,6 @@
   check_mode: false
 
 - name: Install NPM dependencies
-  become: true
-  become_user: "{{ uptime_kuma_user }}"
   community.general.npm:
     path: "{{ uptime_kuma_src }}"
     production: true


### PR DESCRIPTION
When trying to install Uptime Kuma, the tasks for extracting and installing will fail when the ansible user is not root.
